### PR TITLE
Add Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,30 @@
+# compiled output
+**/target/
+workspace/
+**/bin/
+*/.settings/org.sonar.ide.eclipse.core.prefs
+.polyglot.build.properties
+.tycho-consumer-pom.xml
+
+
+# Git
+.git*
+!.git/
+
+# Markdown file
+*.md
+
+
+# IDEs and editors
+
+
+# IDE - VSCode
+.vscode/*
+.history/*
+.devcontainer/
+
+# Dockerfile
+dockerfiles/
+
+# System Files
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,9 @@ bin/
 target/
 workspace/
 */.settings/org.sonar.ide.eclipse.core.prefs
+
+
+
+# VS Code
+.devcontainer
+.vscode

--- a/dockerfiles/Dockerfile.prod
+++ b/dockerfiles/Dockerfile.prod
@@ -15,7 +15,7 @@ COPY ./ /app/
 
 WORKDIR /app/
 
-RUN mvn clean install -DskipTests -Dmaven.test.skip=true -Pfilter-grammar -Pctf-grammar
+RUN mvn clean install -DskipTests -Dmaven.test.skip=true -Dskip-rcp -Pfilter-grammar -Pctf-grammar
 
 FROM alpine:3.16.0
 

--- a/dockerfiles/Dockerfile.prod
+++ b/dockerfiles/Dockerfile.prod
@@ -1,0 +1,22 @@
+# Copyright (c) 2022 École Polytechnique de Montréal
+#
+# All rights reserved. This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0 which
+# accompanies this distribution, and is available at
+# https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+
+FROM alpine:3.16.0 as packager
+
+RUN apk --no-cache add openjdk11-jdk openjdk11-jmods maven
+
+COPY ./ /app/
+
+WORKDIR /app/
+
+RUN mvn clean install -DskipTests -Dmaven.test.skip=true -Pfilter-grammar -Pctf-grammar
+
+FROM alpine:3.16.0
+
+COPY --from=packager /root/.m2/repository/org/eclipse/tracecompass /root/.m2/repository/org/eclipse/tracecompass


### PR DESCRIPTION
I made a multi stage build dockerfile to compile tracecompass. The stage "packager" install the minimum package needed to compile tracecompass. Then it will copy the project inside the container then run the "mvn clean install -DskipTests -Dmaven.test.skip=true -Dskip-rcp -Pfilter-grammar -Pctf-grammar" command to build tracecompass. After the build, it will go to the next stage and this stage will just have the bareminumul configuration to run tracecompass. It will copy tracecompass already install into the new stage. 